### PR TITLE
Graceful fail if scooter fails to get a userAgent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,7 @@ internals.addHeaders = function (request, next) {
         options = Hoek.clone(internals.options);
     }
 
-    var userAgent = request.plugins.scooter;
+    var userAgent = request.plugins.scooter || {};
     var version = parseInt(userAgent.major, 10);
     var headerName = 'Content-Security-Policy';
     var policy;


### PR DESCRIPTION
I've got hapi doing some redirects and (apparently) that can cause the userAgent string to be empty. In that case, scooter returns `undefined`. This prevents blankie from crashing in that case.

```
Uncaught error: Cannot read property 'major' of undefined TypeError: Uncaught error: Cannot read property 'major' of undefined
    at internals.addHeaders (/node_modules/blankie/lib/index.js:167:37)
    at //node_modules/hapi/lib/handler.js:399:22
    at iterate (/node_modules/hapi/node_modules/items/lib/index.js:35:13)
    at done (/node_modules/hapi/node_modules/items/lib/index.js:27:25)
    at finalize (/node_modules/hapi/lib/handler.js:386:69)
    at onServerPreResponse (/index.js:51:32)
    at /hapi/lib/handler.js:399:22
    at iterate (/hapi/node_modules/items/lib/index.js:35:13)
    at Object.exports.serial (/node_modules/hapi/node_modules/items/lib/index.js:38:9)
    at /node_modules/hapi/lib/handler.js:382:15 14100617029
```
