### PR TITLE
Fixed issue where reflectedXss value was treated as array instead of string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,13 @@ internals.arrayValues = [
     'xhrSrc'
 ];
 
-internals.directiveNames = internals.arrayValues.concat(['reportUri', 'reflectedXss']);
+internals.stringValues = [
+    'reportUri',
+    'reflectedXss'
+];
+
+
+internals.directiveNames = internals.arrayValues.concat(internals.stringValues);
 
 internals.directiveMap = {
     'childSrc': 'child-src',
@@ -135,7 +141,7 @@ internals.generatePolicy = function (options) {
         }
 
         var directive = internals.directiveMap[key] || key;
-        if (key === 'reportUri') {
+        if (internals.stringValues.indexOf(key) >= 0) {
             policy.push(directive + ' ' + options[key]);
         }
         else if (key === 'sandbox' && options[key] === true) {
@@ -237,7 +243,7 @@ internals.validateOptions = function (options) {
     var result;
 
     Schema.validate(options, function (err, value) {
-        
+
         if (err) {
             result = err;
             return;


### PR DESCRIPTION
* created `internals.stringValues` for directives which require string
values.
* changed `internals.generatePolicy` method to check whether the key should be
treated as string and act accordingly