### PR TITLE
add 'require-sri-for' directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You may also set `config.plugins.blankie` equal to `false` on a route to disable
 * `reflectedXss`: Value for the `reflected-xss` directive. Must be one of `'allow'`, `'block'` or `'filter'`.
 * `reportOnly`: Append '-Report-Only' to the name of the CSP header to enable report only mode.
 * `reportUri`: Value for the `report-uri` directive. This should be the path to a route that accepts CSP violation reports.
+* `requireSri`: Value for `require-sri-for` directive.
 * `sandbox`: Values for the `sandbox` directive. May be a boolean or one of `'allow-forms'`, `'allow-same-origin'`, `'allow-scripts'` or `'allow-top-navigation'`.
 * `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`.
 * `styleSrc`: Values for the `style-src` directive. Defaults to `'self'`.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You may also set `config.plugins.blankie` equal to `false` on a route to disable
 * `reflectedXss`: Value for the `reflected-xss` directive. Must be one of `'allow'`, `'block'` or `'filter'`.
 * `reportOnly`: Append '-Report-Only' to the name of the CSP header to enable report only mode.
 * `reportUri`: Value for the `report-uri` directive. This should be the path to a route that accepts CSP violation reports.
-* `requireSri`: Value for `require-sri-for` directive.
+* `requireSriFor`: Value for `require-sri-for` directive.
 * `sandbox`: Values for the `sandbox` directive. May be a boolean or one of `'allow-forms'`, `'allow-same-origin'`, `'allow-scripts'` or `'allow-top-navigation'`.
 * `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`.
 * `styleSrc`: Values for the `style-src` directive. Defaults to `'self'`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ internals.arrayValues = [
     'mediaSrc',
     'objectSrc',
     'pluginTypes',
-    'requireSri',
+    'requireSriFor',
     'sandbox',
     'scriptSrc',
     'styleSrc',
@@ -46,7 +46,7 @@ internals.directiveMap = {
     'pluginTypes': 'plugin-types',
     'reflectedXss': 'reflected-xss',
     'reportUri': 'report-uri',
-    'requireSri': 'require-sri-for',
+    'requireSriFor': 'require-sri-for',
     'scriptSrc': 'script-src',
     'styleSrc': 'style-src',
     'xhrSrc': 'xhr-src'

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ internals.arrayValues = [
     'mediaSrc',
     'objectSrc',
     'pluginTypes',
+    'requireSri',
     'sandbox',
     'scriptSrc',
     'styleSrc',
@@ -45,6 +46,7 @@ internals.directiveMap = {
     'pluginTypes': 'plugin-types',
     'reflectedXss': 'reflected-xss',
     'reportUri': 'report-uri',
+    'requireSri': 'require-sri-for',
     'scriptSrc': 'script-src',
     'styleSrc': 'style-src',
     'xhrSrc': 'xhr-src'

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -17,6 +17,7 @@ module.exports = Joi.object({
     reflectedXss: Joi.string().valid('allow', 'block', 'filter'),
     reportOnly: Joi.boolean(),
     reportUri: Joi.string(),
+    requireSri: Joi.array().items(Joi.string()).single(),
     sandbox: [
         Joi.array().items(Joi.string().valid('allow-forms', 'allow-same-origin', 'allow-scripts', 'allow-top-navigation')).single(),
         Joi.boolean()

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -17,7 +17,7 @@ module.exports = Joi.object({
     reflectedXss: Joi.string().valid('allow', 'block', 'filter'),
     reportOnly: Joi.boolean(),
     reportUri: Joi.string(),
-    requireSri: Joi.array().items(Joi.string()).single(),
+    requireSriFor: Joi.array().items(Joi.string()).single(),
     sandbox: [
         Joi.array().items(Joi.string().valid('allow-forms', 'allow-same-origin', 'allow-scripts', 'allow-top-navigation')).single(),
         Joi.boolean()


### PR DESCRIPTION
Enables options for [the new "require-sri-for" directive](https://frederik-braun.com/new-csp-directive-to-make-subresource-integrity-mandatory-require-sri-for.html). Although its currently only available in FF nightly it will probably soon find its way into Chrome & Edge.