### PR TITLE
append CSP headers only HTML content

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,7 +188,11 @@ internals.generatePolicy = function (options, request) {
 
 internals.addHeaders = function (request, reply) {
 
-    if (request.route.settings.plugins.blankie === false) {
+    var response = request.response;
+
+    var contentType = (response.headers||response.output.headers)['content-type'];
+
+    if (request.route.settings.plugins.blankie === false || contentType && contentType !== 'text/html') {
         return reply.continue();
     }
 
@@ -256,11 +260,11 @@ internals.addHeaders = function (request, reply) {
         headerName += '-Report-Only';
     }
 
-    if (!request.response.isBoom) {
-        request.response.headers[headerName] = policy;
+    if (!response.isBoom) {
+        response.headers[headerName] = policy;
     }
     else {
-        request.response.output.headers[headerName] = policy;
+        response.output.headers[headerName] = policy;
     }
 
     return reply.continue();


### PR DESCRIPTION
Currently the response headers will always be extended - even on none HTML content. To avoid unnecessary bloat it first checks if the resource has a supported content type (therefore its either not specified or 'text/html').