### PR TITLE
allow nonce generation for scriptSrc/styleSrc independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ You may also set `config.plugins.blankie` equal to `false` on a route to disable
 * `reportUri`: Value for the `report-uri` directive. This should be the path to a route that accepts CSP violation reports.
 * `requireSriFor`: Value for `require-sri-for` directive.
 * `sandbox`: Values for the `sandbox` directive. May be a boolean or one of `'allow-forms'`, `'allow-same-origin'`, `'allow-scripts'` or `'allow-top-navigation'`.
-* `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`. NOTE: when `generateNonces` is `true`, `'unsafe-inline'` is not allowed here.
+* `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`. NOTE: when `generateNonces` is `true` or `script`, `'unsafe-inline'` is not allowed here.
 * `styleSrc`: Values for the `style-src` directive. Defaults to `'self'`.
-* `generateNonces`: Whether or not to automatically generate nonces. Defaults to `true`. When enabled your templates will have `script-nonce` and `style-nonce` automatically added to their context.
+* `generateNonces`: Whether or not to automatically generate nonces. Defaults to `true`. May be a boolean or one of `'script'` or `'style'`. When enabled your templates will have `script-nonce` and/or `style-nonce` automatically added to their context.

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,17 @@ internals.needQuotes = [
     'eval-script'
 ];
 
+internals.nonceShouldBeGenerated = function (options, key) {
+
+    var keyToConfigMap = {
+        scriptSrc: 'script',
+        styleSrc: 'style'
+    };
+
+    return options.generateNonces === true ||  options.generateNonces === keyToConfigMap[key];
+};
+
+
 internals.generateNonce = function () {
 
     var bytes;
@@ -167,8 +178,7 @@ internals.generatePolicy = function (options, request) {
             return;
         }
 
-        if (options.generateNonces &&
-            (key === 'scriptSrc' || key === 'styleSrc')) {
+        if ((key === 'scriptSrc' || key === 'styleSrc') && internals.nonceShouldBeGenerated(options, key)) {
 
             var nonce = internals.generateNonce();
             var sources = Hoek.clone(options[key]);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -24,5 +24,5 @@ module.exports = Joi.object({
     ],
     scriptSrc: Joi.array().items(Joi.string()).single().default(['self']).when('generateNonces', { is: true, then: Joi.array().items(Joi.string().valid('unsafe-inline').forbidden()) }),
     styleSrc: Joi.array().items(Joi.string()).single().default(['self']),
-    generateNonces: Joi.boolean().default(true)
+    generateNonces: Joi.alternatives().try([Joi.boolean(), Joi.string().valid('script', 'style')]).default(true)
 }).with('reportOnly', 'reportUri');


### PR DESCRIPTION
closes #16 

I've tested this change both with the site that needs `unsafe-inline` for `styleSrc` (so `generateNonces` was set to `scriptSrc`) and with another site where the default `generateNonces` value of `true` was used.