### PR TITLE
#20: minor: Provide a way to get the nonce other than through vision

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -179,8 +179,9 @@ internals.generatePolicy = function (options, request) {
         }
 
         if ((key === 'scriptSrc' || key === 'styleSrc') && internals.nonceShouldBeGenerated(options, key)) {
+            var nonceKey = key + 'Nonce';
 
-            var nonce = internals.generateNonce();
+            var nonce = request.plugins.blankie[nonceKey];
             var sources = Hoek.clone(options[key]);
             sources.push('\'nonce-' + nonce + '\'');
             policy.push(directive + ' ' + sources.join(' '));
@@ -198,6 +199,40 @@ internals.generatePolicy = function (options, request) {
 };
 
 
+// Generate Nonces in advance of any potential use. In particular, make sure they are available before any routes are evaluated.
+internals.makeNonce = function (request, reply) {
+    var options = internals.getOptions(request);
+
+    if (options instanceof Error) {
+        request.server.log(['error', 'blankie'], 'Invalid blankie configuration on route: ' + request.route.path);
+        return reply.continue();
+    }
+
+    ['scriptSrc', 'styleSrc'].forEach(function(key) {
+        if (internals.nonceShouldBeGenerated(options, key)) {                
+            var nonceKey = key + 'Nonce';
+            var nonce = internals.generateNonce();
+
+            request.plugins = request.plugins || {};
+            request.plugins.blankie = request.plugins.blankie || {};
+            request.plugins.blankie[nonceKey] = nonce;
+        }
+    });
+
+    return reply.continue();
+}
+
+
+internals.getOptions = function (request) {
+    if (request.route.settings.plugins.blankie) {
+        return internals.validateOptions(request.route.settings.plugins.blankie);
+    }
+    else {
+        return Hoek.clone(internals.options);
+    }
+}
+
+
 internals.addHeaders = function (request, reply) {
 
     var response = request.response;
@@ -208,18 +243,11 @@ internals.addHeaders = function (request, reply) {
         return reply.continue();
     }
 
-    var options;
+    var options = internals.getOptions(request);
 
-    if (request.route.settings.plugins.blankie) {
-        options = internals.validateOptions(request.route.settings.plugins.blankie);
-
-        if (options instanceof Error) {
-            request.server.log(['error', 'blankie'], 'Invalid blankie configuration on route: ' + request.route.path);
-            return reply.continue();
-        }
-    }
-    else {
-        options = Hoek.clone(internals.options);
+    if (options instanceof Error) {
+        request.server.log(['error', 'blankie'], 'Invalid blankie configuration on route: ' + request.route.path);
+        return reply.continue();
     }
 
     var userAgent = request.plugins.scooter || {};
@@ -329,6 +357,7 @@ exports.register = function (server, options, next) {
         return next(internals.options);
     }
 
+    server.ext('onRequest', internals.makeNonce);
     server.ext('onPreResponse', internals.addHeaders);
     return next();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blankie",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "a content security policy plugin for hapi",
   "main": "index.js",
   "scripts": {

--- a/test/generic.js
+++ b/test/generic.js
@@ -91,6 +91,33 @@ describe('Generic headers', function () {
         });
     });
 
+    it('adds a nonce to plugin properties in request', function (done) {
+
+        var server = new Hapi.Server();
+        server.connection();
+        server.register([Scooter, Blankie], function (err) {
+
+            expect(err).to.not.exist();
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: function (request, reply) {
+                    reply.continue();
+                }
+            });
+
+            server.inject({
+                method: 'GET',
+                url: '/'
+            }, function (res) {
+                expect(res.request.plugins.blankie.scriptSrcNonce.length).to.equal(32);
+                expect(res.request.plugins.blankie.styleSrcNonce.length).to.equal(32);
+                done();
+            });
+        });
+    });
+
     it('does not blow up if Crypto.pseudoRandomBytes happens to throw', function (done) {
 
         var server = new Hapi.Server();


### PR DESCRIPTION
### Problem
We would like to be able to get a nonce to use in a place other than vision (e.g. in a route handler in electrode) ( e.g. https://github.com/electrode-io/electrode/pull/486 ).

### Offered Solution
This reworks Blankie's behavior a bit so that when a request comes in, it will attach the nonce(s) to a `request.plugins.blankie` object.  Thereafter, other plugins can use these nonces if they wish when building a page, and when the normal `onPreResponse` event is fired, these are then extracted and fed into `request.response.source.context` as before/normal.

Note: one of the firefox tests doesn't work for me on master.  