### PR TITLE
Allow unsafe-inline in combination with nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ You may also set `config.plugins.blankie` equal to `false` on a route to disable
 * `reportUri`: Value for the `report-uri` directive. This should be the path to a route that accepts CSP violation reports.
 * `requireSriFor`: Value for `require-sri-for` directive.
 * `sandbox`: Values for the `sandbox` directive. May be a boolean or one of `'allow-forms'`, `'allow-same-origin'`, `'allow-scripts'` or `'allow-top-navigation'`.
-* `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`. NOTE: when `generateNonces` is `true` or `script`, `'unsafe-inline'` is not allowed here.
+* `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`.
 * `styleSrc`: Values for the `style-src` directive. Defaults to `'self'`.
 * `generateNonces`: Whether or not to automatically generate nonces. Defaults to `true`. May be a boolean or one of `'script'` or `'style'`. When enabled your templates will have `script-nonce` and/or `style-nonce` automatically added to their context.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -22,7 +22,7 @@ module.exports = Joi.object({
         Joi.array().items(Joi.string().valid('allow-forms', 'allow-same-origin', 'allow-scripts', 'allow-top-navigation')).single(),
         Joi.boolean()
     ],
-    scriptSrc: Joi.array().items(Joi.string()).single().default(['self']).when('generateNonces', { is: true, then: Joi.array().items(Joi.string().valid('unsafe-inline').forbidden()) }),
+    scriptSrc: Joi.array().items(Joi.string()).single().default(['self']),
     styleSrc: Joi.array().items(Joi.string()).single().default(['self']),
     generateNonces: Joi.alternatives().try([Joi.boolean(), Joi.string().valid('script', 'style')]).default(true)
 }).with('reportOnly', 'reportUri');

--- a/test/generic.js
+++ b/test/generic.js
@@ -91,6 +91,34 @@ describe('Generic headers', function () {
         });
     });
 
+    it('allows setting unsafe-inline in combination with nonce on script-src', function (done) {
+
+        var server = new Hapi.Server();
+        var options = {
+            scriptSrc: ['unsafe-inline']
+        }
+        server.connection();
+        server.route(defaultRoute);
+        server.register([Scooter, { register: Blankie, options }], function (err) {
+
+            expect(err).to.not.exist();
+            server.inject({
+                method: 'GET',
+                url: '/'
+            }, function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers).to.contain('content-security-policy');
+                expect(res.headers['content-security-policy']).to.contain('default-src \'none\'');
+                expect(res.headers['content-security-policy']).to.contain('script-src \'unsafe-inline\' \'nonce-'); // only checks for the nonce- prefix since it's a random value
+                expect(res.headers['content-security-policy']).to.contain('style-src \'self\'');
+                expect(res.headers['content-security-policy']).to.contain('img-src \'self\'');
+                expect(res.headers['content-security-policy']).to.contain('connect-src \'self\'');
+                done();
+            });
+        });
+    });
+
     it('does not blow up if Crypto.pseudoRandomBytes happens to throw', function (done) {
 
         var server = new Hapi.Server();


### PR DESCRIPTION
Hey there,
older browsers that don't support CSP2 can't deal with nonces, so they should be able to fallback to `unsafe-inline`. Currently that isn't allowed in blankie.
Newer browsers will just ignore `unsafe-inline` if a nonce is present.

I added a failing test case and the "fix" to schema.js.

> Consider adding 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers.

from https://csp-evaluator.withgoogle.com