### PR TITLE
Allow setting base-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You may also set `config.plugins.blankie` equal to `false` on a route to disable
 
 ### Options
 
+* `baseUri`: Values for `base-uri` directive. Defaults `'self'`.
 * `childSrc`: Values for `child-src` directive.
 * `connectSrc`: Values for the `connect-src` directive. Defaults `'self'`.
 * `defaultSrc`: Values for the `default-src` directive. Defaults to `'none'`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var internals = {};
 
 
 internals.arrayValues = [
+    'baseUri',
     'childSrc',
     'connectSrc',
     'defaultSrc',
@@ -32,6 +33,7 @@ internals.stringValues = [
 internals.directiveNames = internals.arrayValues.concat(internals.stringValues);
 
 internals.directiveMap = {
+    'baseUri': 'base-uri',
     'childSrc': 'child-src',
     'connectSrc': 'connect-src',
     'defaultSrc': 'default-src',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,6 +1,7 @@
 var Joi = require('joi');
 
 module.exports = Joi.object({
+    baseUri: Joi.array().items(Joi.string()).single().default(['self']),
     childSrc: Joi.array().items(Joi.string()).single(),
     connectSrc: Joi.array().items(Joi.string()).single().default(['self']),
     defaultSrc: Joi.array().items(Joi.string()).single().default(['none']),

--- a/test/generic.js
+++ b/test/generic.js
@@ -39,6 +39,36 @@ describe('Generic headers', function () {
 
                 expect(res.statusCode).to.equal(200);
                 expect(res.headers).to.contain('content-security-policy');
+                expect(res.headers['content-security-policy']).to.contain('base-uri \'self');
+                expect(res.headers['content-security-policy']).to.contain('default-src \'none\'');
+                expect(res.headers['content-security-policy']).to.contain('script-src \'self\' \'nonce-'); // only checks for the nonce- prefix since it's a random value
+                expect(res.headers['content-security-policy']).to.contain('style-src \'self\'');
+                expect(res.headers['content-security-policy']).to.contain('img-src \'self\'');
+                expect(res.headers['content-security-policy']).to.contain('connect-src \'self\'');
+                done();
+            });
+        });
+    });
+
+    it('allows setting base-uri', function (done) {
+
+        var server = new Hapi.Server();
+        var options = {
+            baseUri: ['unsafe-inline', 'https://hapijs.com', 'blob:']
+        }
+        server.connection();
+        server.route(defaultRoute);
+        server.register([Scooter, { register: Blankie, options: options }], function (err) {
+
+            expect(err).to.not.exist();
+            server.inject({
+                method: 'GET',
+                url: '/'
+            }, function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers).to.contain('content-security-policy');
+                expect(res.headers['content-security-policy']).to.contain('base-uri \'unsafe-inline\' https://hapijs.com blob:');
                 expect(res.headers['content-security-policy']).to.contain('default-src \'none\'');
                 expect(res.headers['content-security-policy']).to.contain('script-src \'self\' \'nonce-'); // only checks for the nonce- prefix since it's a random value
                 expect(res.headers['content-security-policy']).to.contain('style-src \'self\'');


### PR DESCRIPTION
I added the ability to set the `base-uri` directive which is part of CSP2.

> Missing base-uri allows the injection of base tags. They can be used to set the base URL for all relative (script) URLs to an attacker controlled domain. Can you set it to 'none' or 'self'?
from https://csp-evaluator.withgoogle.com

Additional information: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri

Are there any other tests necessary? Is it okay to default to `self`on this one?