### PR TITLE
Allow setting 'strict-dynamic'

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ You may also set `config.plugins.blankie` equal to `false` on a route to disable
 * `reportUri`: Value for the `report-uri` directive. This should be the path to a route that accepts CSP violation reports.
 * `requireSriFor`: Value for `require-sri-for` directive.
 * `sandbox`: Values for the `sandbox` directive. May be a boolean or one of `'allow-forms'`, `'allow-same-origin'`, `'allow-scripts'` or `'allow-top-navigation'`.
-* `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`. NOTE: when `generateNonces` is `true` or `script`, `'unsafe-inline'` is not allowed here.
+* `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`.
 * `styleSrc`: Values for the `style-src` directive. Defaults to `'self'`.
 * `generateNonces`: Whether or not to automatically generate nonces. Defaults to `true`. May be a boolean or one of `'script'` or `'style'`. When enabled your templates will have `script-nonce` and/or `style-nonce` automatically added to their context.

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,8 @@ internals.needQuotes = [
     'unsafe-inline',
     'unsafe-eval',
     'inline-script',
-    'eval-script'
+    'eval-script',
+    'strict-dynamic'
 ];
 
 internals.nonceShouldBeGenerated = function (options, key) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -22,7 +22,9 @@ module.exports = Joi.object({
         Joi.array().items(Joi.string().valid('allow-forms', 'allow-same-origin', 'allow-scripts', 'allow-top-navigation')).single(),
         Joi.boolean()
     ],
-    scriptSrc: Joi.array().items(Joi.string()).single().default(['self']).when('generateNonces', { is: true, then: Joi.array().items(Joi.string().valid('unsafe-inline').forbidden()) }),
-    styleSrc: Joi.array().items(Joi.string()).single().default(['self']),
+    scriptSrc: Joi.array().items(Joi.string()).single().default(['self'])
+        .when('generateNonces', { is: [false, 'style'], then: Joi.array().items(Joi.string().valid('strict-dynamic').forbidden()) }),
+    styleSrc: Joi.array().items(Joi.string()).single().default(['self'])
+        .when('generateNonces', { is: [false, 'script'], then: Joi.array().items(Joi.string().valid('strict-dynamic').forbidden()) }),
     generateNonces: Joi.alternatives().try([Joi.boolean(), Joi.string().valid('script', 'style')]).default(true)
 }).with('reportOnly', 'reportUri');


### PR DESCRIPTION
I'm not sure about the schema validation I added. Does it look alright?

CSP1 browsers can fall back to `unsafe-inline` (or other directives), CSP2 browsers will use the nonce, and CSP3 browsers will honor `strict-dynamic`.
Additional information: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic

> Host whitelists can frequently be bypassed. Consider using 'strict-dynamic' in combination with CSP nonces or hashes.
from https://csp-evaluator.withgoogle.com