### PR TITLE
Issue 28: CSP Callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -227,7 +227,7 @@ internals.attachNonces = function (request, h) {
 
         options = internals.validateOptions(options);
         if (options instanceof Error) {
-            request.server.log(['error', 'blankie'], `Invalid blankie configuration from CSP Callback`);
+            request.server.log(['error', 'blankie'], 'Invalid blankie configuration from CSP Callback');
             return h.continue;
         }
     }
@@ -276,7 +276,7 @@ internals.addHeaders = function (request, h) {
 
         options = internals.validateOptions(options);
         if (options instanceof Error) {
-            request.server.log(['error', 'blankie'], `Invalid blankie configuration from CSP Callback`);
+            request.server.log(['error', 'blankie'], 'Invalid blankie configuration from CSP Callback');
             return h.continue;
         }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -222,6 +222,15 @@ internals.attachNonces = function (request, h) {
             return h.continue;
         }
     }
+    else if (internals.cspCallback) {
+        options = internals.cspCallback(request);
+
+        options = internals.validateOptions(options);
+        if (options instanceof Error) {
+            request.server.log(['error', 'blankie'], `Invalid blankie configuration from CSP Callback`);
+            return h.continue;
+        }
+    }
     else {
         options = Hoek.clone(internals.options);
     }
@@ -259,6 +268,15 @@ internals.addHeaders = function (request, h) {
 
         if (options instanceof Error) {
             request.server.log(['error', 'blankie'], `Invalid blankie configuration on route: ${request.route.path}`);
+            return h.continue;
+        }
+    }
+    else if (internals.cspCallback) {
+        options = internals.cspCallback(request);
+
+        options = internals.validateOptions(options);
+        if (options instanceof Error) {
+            request.server.log(['error', 'blankie'], `Invalid blankie configuration from CSP Callback`);
             return h.continue;
         }
     }
@@ -362,14 +380,19 @@ internals.validateOptions = function (options) {
     return result;
 };
 
+internals.cspCallback = null;
 
 exports.plugin = {
     register: function (server, options) {
 
-        internals.options = internals.validateOptions(options);
-
-        if (internals.options instanceof Error) {
-            throw internals.options;
+        if (typeof options === 'function') {
+            internals.cspCallback = options;
+        }
+        else {
+            internals.options = internals.validateOptions(options);
+            if (internals.options instanceof Error) {
+                throw internals.options;
+            }
         }
 
         server.ext('onPreHandler', internals.attachNonces);

--- a/test/index.js
+++ b/test/index.js
@@ -25,25 +25,4 @@ describe('Blankie', () => {
             }
         }])).to.reject(Error, 'child "reportOnly" fails because ["reportOnly" must be a boolean]');
     });
-
-    it.only('allows a callback as the only option', async () => {
-
-        const cspCallback = function () {
-
-            const options = {};
-            options['base-uri'] = 'self';
-            return options;
-        };
-        const server = Hapi.server();
-        await server.register([Scooter, {
-            plugin: Blankie,
-            options: cspCallback
-        }]);
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-        expect(res.headers).to.contain('content-security-policy');
-        expect(res.headers['content-security-policy']).to.contain('base-uri \'self');
-    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -25,4 +25,25 @@ describe('Blankie', () => {
             }
         }])).to.reject(Error, 'child "reportOnly" fails because ["reportOnly" must be a boolean]');
     });
+
+    it.only('allows a callback as the only option', async () => {
+
+        const cspCallback = function () {
+
+            const options = {};
+            options['base-uri'] = 'self';
+            return options;
+        };
+        const server = Hapi.server();
+        await server.register([Scooter, {
+            plugin: Blankie,
+            options: cspCallback
+        }]);
+        const res = await server.inject({
+            method: 'GET',
+            url: '/'
+        });
+        expect(res.headers).to.contain('content-security-policy');
+        expect(res.headers['content-security-policy']).to.contain('base-uri \'self');
+    });
 });

--- a/test/test-callback.js
+++ b/test/test-callback.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Blankie = require('../');
+const Hapi = require('hapi');
+const Scooter = require('scooter');
+
+const { expect } = require('code');
+const { describe, it } = exports.lab = require('lab').script();
+
+describe('Blankie', () => {
+    it('allows a callback as the only option', async () => {
+
+        const cspCallback = function (req) {
+            const options = {};
+            options.baseUri = 'self';
+            return options;
+        };
+        const server = Hapi.server();
+        await server.register([Scooter, {
+            plugin: Blankie,
+            options: cspCallback
+        }]);
+        const res = await server.inject({
+            method: 'GET',
+            url: '/'
+        });
+        expect(res.headers).to.contain('content-security-policy');
+        expect(res.headers['content-security-policy']).to.contain('base-uri \'self');
+    });
+});

--- a/test/test-callback.js
+++ b/test/test-callback.js
@@ -8,9 +8,11 @@ const { expect } = require('code');
 const { describe, it } = exports.lab = require('lab').script();
 
 describe('Blankie', () => {
+
     it('allows a callback as the only option', async () => {
 
         const cspCallback = function (req) {
+
             const options = {};
             options.baseUri = 'self';
             return options;


### PR DESCRIPTION
This allows one to use a callback to build the CSP. This allows for more dynamic handling of the CSP features/options.

Reference issue: https://github.com/nlf/blankie/issues/28