### PR TITLE
feat: report-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You may also set `config.plugins.blankie` equal to `false` on a route to disable
 * `reflectedXss`: Value for the `reflected-xss` directive. Must be one of `'allow'`, `'block'` or `'filter'`.
 * `reportOnly`: Append '-Report-Only' to the name of the CSP header to enable report only mode.
 * `reportUri`: Value for the `report-uri` directive. This should be the path to a route that accepts CSP violation reports.
+* `reportTo`: Name of the group defined in the `Report-to` header. This replaces `report-uri` in browsers that already support it.
 * `requireSriFor`: Value for `require-sri-for` directive.
 * `sandbox`: Values for the `sandbox` directive. May be a boolean or one of `'allow-forms'`, `'allow-same-origin'`, `'allow-scripts'` or `'allow-top-navigation'`.
 * `scriptSrc`: Values for the `script-src` directive. Defaults to `'self'`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,7 @@ internals.arrayValues = [
 
 internals.stringValues = [
     'reportUri',
+    'reportTo',
     'reflectedXss'
 ];
 
@@ -52,6 +53,7 @@ internals.directiveMap = {
     'pluginTypes': 'plugin-types',
     'reflectedXss': 'reflected-xss',
     'reportUri': 'report-uri',
+    'reportTo': 'report-to',
     'requireSriFor': 'require-sri-for',
     'scriptSrc': 'script-src',
     'styleSrc': 'style-src',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -20,6 +20,7 @@ module.exports = Joi.object({
     reflectedXss: Joi.string().valid('allow', 'block', 'filter'),
     reportOnly: Joi.boolean(),
     reportUri: Joi.string(),
+    reportTo: Joi.string(),
     requireSriFor: Joi.array().items(Joi.string()).single(),
     sandbox: [
         Joi.array().items(Joi.string().valid('allow-forms', 'allow-same-origin', 'allow-scripts', 'allow-top-navigation')).single(),

--- a/test/generic.js
+++ b/test/generic.js
@@ -279,7 +279,7 @@ describe('Generic headers', () => {
         expect(res.headers['content-security-policy']).to.contain('worker-src \'self\'');
     });
 
-    it('sends report only headers when requested', async () => {
+    it('sends report only headers when requested using report-uri', async () => {
 
         const server = Hapi.server();
         server.route(defaultRoute);
@@ -301,6 +301,56 @@ describe('Generic headers', () => {
         expect(res.headers).to.contain('content-security-policy-report-only');
         expect(res.headers['content-security-policy-report-only']).to.contain('default-src \'self\'');
         expect(res.headers['content-security-policy-report-only']).to.contain('report-uri /csp_report');
+    });
+
+    it('sends report only headers when requested using report-to', async () => {
+
+        const server = Hapi.server();
+        server.route(defaultRoute);
+        await server.register([Scooter, {
+            plugin: Blankie,
+            options: {
+                defaultSrc: 'self',
+                reportOnly: true,
+                reportTo: 'csp_report'
+            }
+        }]);
+
+        const res = await server.inject({
+            method: 'GET',
+            url: '/'
+        });
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.headers).to.contain('content-security-policy-report-only');
+        expect(res.headers['content-security-policy-report-only']).to.contain('default-src \'self\'');
+        expect(res.headers['content-security-policy-report-only']).to.contain('report-to csp_report');
+    });
+
+    it('sends report only headers when requested using both report-uri and report-to', async () => {
+
+        const server = Hapi.server();
+        server.route(defaultRoute);
+        await server.register([Scooter, {
+            plugin: Blankie,
+            options: {
+                defaultSrc: 'self',
+                reportOnly: true,
+                reportUri: '/csp_report',
+                reportTo: 'csp_report'
+            }
+        }]);
+
+        const res = await server.inject({
+            method: 'GET',
+            url: '/'
+        });
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.headers).to.contain('content-security-policy-report-only');
+        expect(res.headers['content-security-policy-report-only']).to.contain('default-src \'self\'');
+        expect(res.headers['content-security-policy-report-only']).to.contain('report-uri /csp_report');
+        expect(res.headers['content-security-policy-report-only']).to.contain('report-to csp_report'); // browser will only use report-to if it already supports it
     });
 
     it('does not crash when responding with an error', async () => {


### PR DESCRIPTION
This is work in progress. `report-to` aims to replace `report-uri` in CSP 3 but it only has support [in certain browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to#Browser_compatibility) (chrome and android > v70).

Basically what is missing from this PR is a rule in Joi that supports the desired behaviour and add it in [schema](https://github.com/nlf/blankie/compare/master...sericaia:feat/report-to?expand=1#diff-f412f4722a52cf22ed3d0a9a694b837dL34).

So we want to have the following different rules:
* use report-only only when report-uri is present (as we currently have):
`schema.with('reportOnly', 'reportUri'); `

* same as before, but for report-to (when reportTo replaces reportUri):
`schema.with('reportOnly', 'reportTo');`

* we can also have both `reportUri` and `reportTo` and the browser will decide which one to use

Something like `schema.with('reportOnly', ['reportUri', 'reportTo']);` or using [object.or](https://github.com/hapijs/joi/blob/master/API.md#objectorpeers) `schema.or(schema.with('reportOnly', 'reportUri'), schema.with('reportOnly', 'reportTo'))`

I couldn't find a way to properly do it in Joi. @nlf do you know if it is possible in any way?